### PR TITLE
Add:投稿を削除するとき、ログアウトするときにアラートを表示する。

### DIFF
--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   </li>
   <li class="list-inline-item">
-    <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete } do %>
+    <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } do %>
       <%= t('defaults.destroy') %>
     <% end %>
   </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
           <%= link_to t('profiles.show.title'), profiles_path, class: 'nav-link text-white', style: 'font-family: serif;' %>
         </li>
         <li class="nav-item">
-          <%= link_to t('defaults.logout'), logout_path, class: 'nav-link text-white', data: { turbo_method: :delete }, style: 'font-family: serif;' %>
+          <%= link_to t('defaults.logout'), logout_path, class: 'nav-link text-white', data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, style: 'font-family: serif;' %>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## 概要
投稿を削除するとき、ログアウトするときにアラートが表示されるようにしました。

## 確認方法
投稿を削除するとき、ログアウトするときにアラートが表示されることを確認して下さい。

## 影響範囲
特になし

## チェックリスト
- [x] 投稿を削除するときにアラートが表示される
- [x] ログアウトする時にアラートが表示される

