### PR TITLE
Fix: いいね機能の修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,17 +3,7 @@
 //= require bootstrap-sprockets
 
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+Turbo.session.drive = false
 import "@hotwired/turbo-rails"
 import "controllers"
-
-document.addEventListener('DOMContentLoaded', () => {
-	console.log('DOMContentLoaded');
-
-	const buttons = document.querySelectorAll('.button');
-
-	buttons.forEach(button => {
-		button.addEventListener('click', () => {
-			alert("ログイン後にいいね機能が使えます");
-		});
-	});
-});
+import './custom/reiatu_alert'

--- a/app/javascript/custom/reiatu_alert.js
+++ b/app/javascript/custom/reiatu_alert.js
@@ -1,0 +1,9 @@
+'use strict';
+
+	const buttons = document.querySelectorAll('.button');
+
+	buttons.forEach(button => {
+		button.addEventListener('click', () => {
+			alert("ログイン後にいいね機能が使えます");          
+		});    
+	}); 

--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   </li>
   <li class="list-inline-item">
-    <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } do %>
+    <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo: true, turbo_method: :delete, turbo_confirm: "削除しますか？" } do %>
       <%= t('defaults.destroy') %>
     <% end %>
   </li>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -24,7 +24,7 @@
           <p class="text-center"><%= t('.no_result') %></p>
         <% end %>
       </div>
-        <%= paginate @posts %>
+      <%= paginate @posts %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
           <%= link_to t('profiles.show.title'), profiles_path, class: 'nav-link text-white', style: 'font-family: serif;' %>
         </li>
         <li class="nav-item">
-          <%= link_to t('defaults.logout'), logout_path, class: 'nav-link text-white', data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, style: 'font-family: serif;' %>
+          <%= link_to t('defaults.logout'), logout_path, class: 'nav-link text-white', data: { turbo: true, turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, style: 'font-family: serif;' %>
         </li>
       </ul>
     </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,4 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.3.1/dist/js/bootstrap.esm.js"
 pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.8/lib/index.js"
 pin "stimulus-autocomplete", to: "https://ga.jspm.io/npm:stimulus-autocomplete@3.1.0/src/autocomplete.js"
+pin_all_from 'app/javascript/custom', under: 'custom'


### PR DESCRIPTION
## 概要
ログイン前のいいねボタンを、Turbo Driveが反映されないようにした。

## 確認方法
ログイン前にどのページでも、ページをリロードせずにいいねボタンを押すと、必ずアラートが表示されることを確認する。

## 影響範囲
Turbo Driveを使用している「削除」リンクや「ログアウト」リンクは、Turbo Driveを使うためにdata-turbo="true"を追加する必要がある。

## チェックリスト
後にテストコードを書く。