### PR TITLE
Post index order

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  skip_before_action :require_login, only: %i[index show search search_shikai search_bankai search_username]
+  skip_before_action :require_login, only: %i[index show search search_shikai search_bankai search_username index_new_order index_edit_order]
   layout 'layouts/autocomplete', only: %i[ search_shikai search_bankai search_username search_tag ]
 
   def index

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = Post.where(is_draft: false).includes(:user).order(updated_at: :desc).page(params[:page])
+    @posts = Post.where(is_draft: false).includes(:user).order(created_at: :desc).page(params[:page])
   end 
 
   def search
@@ -21,6 +21,25 @@ class PostsController < ApplicationController
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: true).where(is_draft: false).includes(:user).order(updated_at: :desc).page(params[:page])
   end
+
+  def index_new_order
+    posts= Post.where(is_draft: false).includes(:user).order(created_at: :desc).page(params[:page])
+    render turbo_stream: turbo_stream.replace(
+      "js-index-order",
+      partial: 'posts/index_order',
+      locals: { posts: posts }
+    )   
+  end
+
+  def index_edit_order
+    posts= Post.where(is_draft: false).includes(:user).order(updated_at: :desc).page(params[:page])
+    render turbo_stream: turbo_stream.replace(
+      "js-index-order",
+      partial: 'posts/index_order',
+      locals: { posts: posts }
+    )   
+  end
+
   def search_shikai
     @posts = Post.where("shikai like ?", "%#{params[:q]}%").where(is_draft: false)
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,7 +8,7 @@ import "@hotwired/turbo-rails"
 import "controllers"
 'use strict';
 
-const buttons = document.querySelectorAll('.button');
+const buttons = document.querySelectorAll('.before-button');
 
 buttons.forEach(button => {
 	button.addEventListener('click', () => {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,3 +15,13 @@ buttons.forEach(button => {
 		alert("ログイン後にいいね機能が使えます");              
 	});    
 });
+
+document.getElementById('js-active-new').addEventListener('click', function() {
+	document.getElementById('js-active-edit').classList.remove('active');
+	this.classList.add('active');
+});
+
+document.getElementById('js-active-edit').addEventListener('click', function() {
+	document.getElementById('js-active-new').classList.remove('active');
+	this.classList.add('active');
+});

--- a/app/views/posts/_before_login_reiatus_button.html.erb
+++ b/app/views/posts/_before_login_reiatus_button.html.erb
@@ -1,3 +1,3 @@
-<div class="me-4 button" style="color: #026CE8; text-decoration:none;">
+<div class="me-4 before-button" style="color: #026CE8; text-decoration:none; opacity: 0.8;">
   <i class="fa fa-thumbs-o-up me-1" aria-hidden="true"></i>霊圧
 </div>

--- a/app/views/posts/_index_order.html.erb
+++ b/app/views/posts/_index_order.html.erb
@@ -1,0 +1,12 @@
+<%= turbo_frame_tag "js-index-order", frame: posts do %>
+  <div class="row" style="justify-content: space-around;">
+    <% if posts.present? %>
+      <% posts.each do |post| %>
+        <%= render partial: 'posts/post', locals: { post: post } %>
+      <% end %>
+    <% else %>
+      <p class="text-center"><%= t('.no_result') %></p>
+    <% end %>
+  </div>
+  <%= paginate posts %>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -4,14 +4,10 @@
       <div class="post-item-img">
         <%= image_tag post.image.url, class: 'card-img-top', style: 'width: 100%; height: 100%;', alt: "オリジナル斬魄刀の画像" %>
       </div>
-      <% if current_user&.own?(post) %>
-        <%= render 'posts/crud_menus', post: post %>
-      <% else %>
-        <div style="align-items: center; display: flex;" class="mt-1 ms-2">
-          <%= image_tag post.user.avatar.url, class: 'rounded-circle', size: '30x30', alt: "アバター" %>
-          <div class="ms-2"><%= post.user.name %></div>
-        </div>
-      <% end %>
+      <div style="align-items: center; display: flex;" class="mt-1 ms-2">
+        <%= image_tag post.user.avatar.url, class: 'rounded-circle', size: '30x30', alt: "アバター" %>
+        <div class="ms-2"><%= post.user.name %></div>
+      </div>
     </div>
     <div class="col-md-8">
       <div class="card-body p-2 ps-1">
@@ -38,7 +34,7 @@
         <h5 class="card-title mb-1">
           【<%= t('posts.show.shikai') %>】
           <ruby>
-            <%= link_to post.shikai, post_path(post) %>
+            <%= link_to post.shikai, post_path(post), data: { turbo: false } %>
             <rt><%= post.shikai_hurigana %></rt>
           </ruby>
         </h5>

--- a/app/views/posts/_tag_list.html.erb
+++ b/app/views/posts/_tag_list.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-1">
   <% tag_list.each do |tag| %>
     <span class="bg-dark me-1 p-1" style="font-size: 12px;">
-      <%= link_to tag, search_path(tag_name: tag), class: "text-white", style: 'font-size: 12px; text-decoration: none;' %>
+      <%= link_to tag, search_path(tag_name: tag), class: "text-white", style: 'font-size: 12px; text-decoration: none;', data: { turbo: false } %>
     </span>
   <% end %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,16 +15,13 @@
 <%= render 'shared/search' %>
 <h3 id="post" style="text-align: center;" class="mt-5 mb-3"><%= t('.title') %></h3>
 <div class="container pt-3">
+<div class="btn-group mb-3" role="group" aria-label="Basic outlined example">
+  <%= link_to "新着順", index_new_order_posts_path, class: "active btn btn-outline-dark", id: "js-active-new", type: "button", data: { turbo: true, turbo_method: :get } %>
+  <%= link_to "更新順", index_edit_order_posts_path, class: "btn btn-outline-dark", id: "js-active-edit", type: "button", data: { turbo: true, urbo_method: :get } %>
+</div>
   <div class="row">
     <div class="col-12">
-      <div class="row" style="justify-content: space-around;">
-        <% if @posts.present? %>
-          <%= render @posts %>
-        <% else %>
-          <p class="text-center"><%= t('.no_result') %></p>
-        <% end %>
-      </div>
-      <%= paginate @posts %>
+      <%= render 'posts/index_order', posts: @posts %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resource :profiles, only: %i[show edit update]
   resources :posts do
+    get :index_new_order, on: :collection
+    get :index_edit_order, on: :collection
     get :search_shikai, on: :collection
     get :search_bankai, on: :collection
     get :search_username, on: :collection


### PR DESCRIPTION
## 概要
投稿一覧で「新着順」と「更新順」で任意に投稿の順番を入れ替えられるようにしました。

## 確認方法
後にテストコードを書きます。まずは手動で確認して下さい。

## 影響範囲
Turboフレーム内のlink_toメソッドに影響が及ぶので、data: { turbo: false }を追加しました。

## チェックリスト
後にテストコードを書きます。

## コメント
ログイン前のいいね機能のアラートがTurboによって動かない場合があるので、そのバグは後から直します。