### PR TITLE
Add: AI生成後の画面遷移の挙動の実装

### DIFF
--- a/app/views/ai_posts/ai_generate.html.erb
+++ b/app/views/ai_posts/ai_generate.html.erb
@@ -28,7 +28,32 @@
           <td><%= @meigen %></td>
         </tr>
       </table>
-      <%= link_to '入力ページに戻る', new_ai_post_path %>
+      <div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+        <%= link_to "https://twitter.com/share?url=
+        #{ root_url }&text=【始解】#{ @post.shikai }#{ @post.shikai_hurigana.present? ? '('+@post.shikai_hurigana+')' : '' }
+         %0a#{ '【卍解】'+@post.bankai if @post.bankai.present? }#{ @post.bankai_hurigana.present? ? '('+@post.bankai_hurigana+')' : '' }
+         %0a%0a#{@post.detail}
+         %0a%23BLEACH%20%20%0a%23BLEACH_anime%20%20%0a%23オリジナル斬魄刀%20%20%0a%23オリジナル斬魄刀投稿サイト%20%0a",
+         target: '_blank', class: 'btn btn-dark mt-2' do %>
+           Twitterでシェアする
+         <% end %>  
+         <% if logged_in? %>
+         <%= form_with model: @post, url: new_ai_path, method: :get, local: true do |f| %>
+           <%= f.hidden_field :shikai %>
+           <%= f.hidden_field :shikai_hurigana %>
+           <%= f.hidden_field :ability %>
+           <%= f.hidden_field :bankai %>
+           <%= f.hidden_field :bankai_hurigana %>
+           <%= f.hidden_field :detail %>
+           <%= f.hidden_field :tag_list %>
+           <%= f.submit "内容を保存or編集or投稿する", class: "mt-2 complete-btn btn btn-dark" %>
+         <% end %>
+       <% end %>
+         <%= link_to 'もう一度AIで創る', new_ai_post_path, class: 'mt-2 btn btn-dark' %>
+      </div>
+         <% unless logged_in? %>
+           <p class="text-center mt-2"><%= link_to 'ログイン', login_path %>すると斬魄刀の内容を保存したり投稿、編集したりすることができます。</p>
+         <% end %>
     </div>
   </div>
 </div>

--- a/app/views/ai_posts/new.html.erb
+++ b/app/views/ai_posts/new.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-center">AIで創る</h1>
     <div class="col-lg-10 offset-lg-1">
       <h2 style="font-size: 20px;" class="fw-bold text-center">↓斬魄刀の情報を入力して下さい↓</h2>
-      <%= form_with(url: ai_generate_path, method: :get) do |form| %>
+      <%= form_with(url: ai_generate_path, method: :post) do |form| %>
         <div class="form-group mt-4">
           <%= form.label :ability, '斬魄刀の能力は？【必須】', style: 'font-size: 20px;' %><br>
           <div class="row">
@@ -50,11 +50,6 @@
           </div>
         </div> 
         <div class="form-group mt-4">
-          <%= form.label :kangi_text, '好きな漢字を一文字入力して下さい。【必須】', style: 'font-size: 20px;' %><br>
-          <%= form.text_field :kangi_text, class: 'form-control mt-3', style: 'width: 200px;', placeholder: '優' %>
-          <p style="font-size: 12px;">※この漢字が始解名、卍解名に含まれます。</p>
-        </div>
-        <div class="form-group mt-4">
           <%= form.label :meigen, 'BLEACHの好きな名言は？【任意】', style: 'font-size: 20px;' %><br>
           <div class="row">
             <% ['憧れは、理解から最も遠い感情だよ',
@@ -62,7 +57,7 @@
                 '戦争なんて始めた瞬間からどっちも悪だよ',
                 '乱菊が泣かんでも済むようにしたる',
                 '5回とも、同じ人を好きになる',
-                '貴様が、私の誇りに刃を向けたからだ',
+                '貴様が私の誇りに刃を向けたからだ',
                 '奇跡は一度、だったよな？じゃあ二度目は何だ？',
                 'これが…そうか…この掌(てのひら)にあるものが…心か']
               .each_with_index do |meigen, index| %>
@@ -77,8 +72,13 @@
             <% end %>
           </div>
         </div>
+        <div class="form-group mt-4">
+          <%= form.label :kangi_text, '好きな漢字を一文字入力して下さい。【必須】', style: 'font-size: 20px;' %><br>
+          <%= form.text_field :kangi_text, class: 'form-control mt-3', style: 'width: 200px;', placeholder: '優' %>
+          <p style="font-size: 12px;">※この漢字が始解名、卍解名に含まれます。</p>
+        </div>
         <div style="display: flex; justify-content: center; margin-top: 50px;">
-        <%= form.submit "AIに斬魄刀を作ってもらう", class: 'btn btn-dark' %>
+          <%= form.submit "AIに斬魄刀を作ってもらう", class: 'btn btn-dark' %>
         </div>
       <% end %>
 

--- a/app/views/ai_posts/new_ai.html.erb
+++ b/app/views/ai_posts/new_ai.html.erb
@@ -1,0 +1,8 @@
+<div class="container mt-3">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <h1>保存or編集or投稿する</h1>
+      <%= render 'posts/form', { post: @post } %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -70,7 +70,7 @@
     </div>
   </div>
   <div style="display: flex; justify-content: space-around; margin-top: 50px;">
-    <% if 'new' == action_name || post.is_draft == true || 'create' == action_name %>
+    <% if 'new' == action_name || post.is_draft == true || 'create' == action_name || 'new_ai' == action_name %>
       <%= f.submit t('defaults.draft'), class: 'btn btn-dark' %>
     <% end %>
     <% if 'edit' == action_name && post.is_draft == false %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -54,17 +54,7 @@
           <% else %>
             <%= render 'posts/before_login_reiatus_button', post: post %>
           <% end %>
-          <% if post.is_draft == false %>
-            <% if post.shikai_hurigana.present? %>
-              <%= link_to "https://twitter.com/share?url=#{ request.url }&text=【斬魄刀】%0a#{ post.shikai }(#{ post.shikai_hurigana })%0a%0aオリジナル斬魄刀をシェアします！%0a%23BLEACH%20%20%23BLEACH_anime%20%20%23オリジナル斬魄刀投稿サイト%20", target: '_blank' do %>
-                <%= fa_stacked_icon "twitter", base: "square-o", style: 'color: #3399FF;' %>
-              <% end %>
-            <% else %>
-              <%= link_to "https://twitter.com/share?url=#{ request.url }&text=【斬魄刀】%0a#{ post.shikai }%0a%0aオリジナル斬魄刀をシェアします！%0a%23BLEACH%20%20%23BLEACH_anime%20%20%23オリジナル斬魄刀投稿サイト%20", target: '_blank' do %>
-                <%= fa_stacked_icon "twitter", base: "square-o", style: 'color: #3399FF;' %>
-              <% end %>
-            <% end %>
-          <% end %>
+          <%= render 'posts/twitter_share', post: post %>
         </div>
       </div>
     </div>

--- a/app/views/posts/_twitter_share.html.erb
+++ b/app/views/posts/_twitter_share.html.erb
@@ -1,0 +1,10 @@
+<% if post.is_draft == false %>
+  <%= link_to "https://twitter.com/share?url=
+  #{ request.url }&text=オリジナル斬魄刀をシェアします！
+  %0a【始解】#{ post.shikai }#{ post.shikai_hurigana.present? ? '('+post.shikai_hurigana+')' : '' }
+  %0a#{ '【卍解】'+post.bankai if post.bankai.present? }#{ post.bankai_hurigana.present? ? '('+post.bankai_hurigana+')' : '' }
+  %0a%0a%23BLEACH%20%20%0a%23BLEACH_anime%20%20%0a%23オリジナル斬魄刀%20%20%0a%23オリジナル斬魄刀投稿サイト%20%0a", target: '_blank' do %>
+      <%= fa_stacked_icon "twitter", base: "square-o", style: 'color: #3399FF;' %>
+    <% end %> 
+<% end %>
+

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,17 +11,7 @@
       </div>
       <%= render 'crud_menus', post: @post if current_user&.own?(@post) %>
       <div style="display: flex; justify-content: flex-end; align-items: center;">
-        <% if @post.is_draft == false %>
-          <% if @post.shikai_hurigana.present? %>
-            <%= link_to "https://twitter.com/share?url=#{ request.url }&text=【斬魄刀】%0a#{ @post.shikai }(#{ @post.shikai_hurigana })%0a%0aオリジナル斬魄刀をシェアします！%0a%23BLEACH%20%20%23BLEACH_anime%20%20%23オリジナル斬魄刀投稿サイト%20", target: '_blank' do %>
-              <%= fa_stacked_icon "twitter", base: "square-o", style: 'color: #3399FF;' %>
-            <% end %>
-          <% else %>
-            <%= link_to "https://twitter.com/share?url=#{ request.url }&text=【斬魄刀】%0a#{ @post.shikai }%0a%0aオリジナル斬魄刀をシェアします！%0a%23BLEACH%20%20%23BLEACH_anime%20%20%23オリジナル斬魄刀投稿サイト%20", target: '_blank' do %>
-              <%= fa_stacked_icon "twitter", base: "square-o", style: 'color: #3399FF;' %>
-            <% end %>
-          <% end %>
-        <% end %>
+        <%= render 'posts/twitter_share', post: @post %>
       </div>
       <table class="table">
         <%= render 'posts/tag_list', tag_list: @post.tag_list %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,9 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
   get 'search', to: 'posts#search'
-  get 'ai_generate', to: 'ai_posts#ai_generate'
+  post 'ai_generate', to: 'ai_posts#ai_generate'
   get 'aaaaa', to: 'ai_posts#aaaaa'
+  get 'new_ai', to: 'ai_posts#new_ai'
 
   resources :users, only: %i[new create]
   resource :profiles, only: %i[show edit update] do


### PR DESCRIPTION
## 概要
未ログインの場合、AI生成後にTwitterシェアするか、もう一度AIで生成するか、ログインするのかが選べるようにしました。
ログインしている状態でAI生成をすると、Twitterシェアするか、内容を保存or編集or投稿するか、もう一度AIで生成するのかが選べるようにしました。

## 確認方法
/ai_posts/new
未ログイン状態とログインした状態それぞれでAI生成がうまくいくことを確認して下さい。その後にTwitterシェアするか、もう一度AIで生成するか、内容を保存or編集or投稿するかなどのボタンを押して正常に動くことを確認して下さい。
後にテストコードを書きます。

## 影響範囲
特になし

## チェックリスト
後にテストコードを書きます。

## コメント
FatControllerは後ほど直します。コードがぐちゃぐちゃなのでRUNTEQ祭締め切りまでにはリファクタリングをしてFatControllerを直し、Lintが通るように修正します。RSpecもRUNTEQ祭締め切りまでには書きます。