### PR TITLE
Fix: タグ付け機能で全角コンマでも区切れるようにした

### DIFF
--- a/config/initializers/tag.rb
+++ b/config/initializers/tag.rb
@@ -1,0 +1,1 @@
+ActsAsTaggableOn.delimiter = [',' , '，', '、']


### PR DESCRIPTION
## 概要
全角コンマや句読点でタグを区切れるようにしました。